### PR TITLE
Add Google sign-in button to login modal

### DIFF
--- a/Jarvis Ui/templates/cloud/components/jarvis/login-modal.tsx
+++ b/Jarvis Ui/templates/cloud/components/jarvis/login-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { XIcon, LoaderCircleIcon, SparklesIcon } from "lucide-react";
@@ -10,6 +10,34 @@ import {
 } from "@/components/jarvis/auth-session";
 
 const API_BASE = "https://jarvis-auth-service.dexproject.workers.dev";
+const DESKTOP_AUTH_CALLBACK_URL =
+  process.env.NEXT_PUBLIC_JARVIS_AUTH_CALLBACK_URL || "";
+
+function buildGoogleAuthUrl() {
+  if (typeof window === "undefined") {
+    return `${API_BASE}/api/auth/google`;
+  }
+
+  const authUrl = new URL(`${API_BASE}/api/auth/google`);
+  const currentUrl = new URL(window.location.href);
+
+  if ((window as any).assistantAPI) {
+    authUrl.searchParams.set(
+      "return_to",
+      DESKTOP_AUTH_CALLBACK_URL || "jarvis-desktop://auth",
+    );
+  } else if (
+    currentUrl.protocol === "http:" ||
+    currentUrl.protocol === "https:"
+  ) {
+    authUrl.searchParams.set(
+      "return_to",
+      `${currentUrl.origin}${currentUrl.pathname}`,
+    );
+  }
+
+  return authUrl.toString();
+}
 
 type LoginModalProps = {
   open: boolean;
@@ -23,7 +51,42 @@ export function LoginModal({ open, onClose, onSuccess }: LoginModalProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleAuthCallback = async (data: any) => {
+      if (!data?.token || !data?.user) return;
+
+      const nextUser = {
+        ...data.user,
+        name: data.user?.name || data.user?.email?.split("@")[0],
+        settings: {
+          autoSync: true,
+          preferWebAi: true,
+          language: "auto",
+          ...(data.user?.settings || {}),
+        },
+      } satisfies AuthUser;
+
+      await persistAuthSession(data.token, nextUser);
+      onSuccess(nextUser, data.token);
+      setGoogleLoading(false);
+      setError(null);
+      onClose();
+    };
+
+    const removeListener = (window as any).assistantAPI?.onEvent?.(
+      "auth:callback",
+      handleAuthCallback,
+    );
+
+    return () => {
+      removeListener?.();
+    };
+  }, [onClose, onSuccess]);
 
   if (!open) return null;
 
@@ -101,6 +164,17 @@ export function LoginModal({ open, onClose, onSuccess }: LoginModalProps) {
     }
   }
 
+  function handleGoogleLogin() {
+    if (typeof window === "undefined") {
+      setError("Google login is not available in this environment.");
+      return;
+    }
+
+    setGoogleLoading(true);
+    setError(null);
+    window.location.href = buildGoogleAuthUrl();
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div className="relative w-full max-w-sm rounded-2xl border border-white/10 bg-[#1a1a1a] p-7 shadow-2xl">
@@ -162,7 +236,7 @@ export function LoginModal({ open, onClose, onSuccess }: LoginModalProps) {
 
           <Button
             type="submit"
-            disabled={loading}
+            disabled={loading || googleLoading}
             className="mt-1 h-11 w-full rounded-xl bg-white font-medium text-black transition-colors hover:bg-zinc-200"
           >
             {loading ? (
@@ -173,6 +247,57 @@ export function LoginModal({ open, onClose, onSuccess }: LoginModalProps) {
               "회원가입"
             )}
           </Button>
+
+          {mode === "login" && (
+            <>
+              <div className="relative py-1">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t border-white/10" />
+                </div>
+                <div className="relative flex justify-center text-[10px] uppercase">
+                  <span className="bg-[#1a1a1a] px-2 text-zinc-500">또는</span>
+                </div>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                disabled={loading || googleLoading}
+                onClick={handleGoogleLogin}
+                className="h-11 w-full rounded-xl border-white/10 bg-white/5 font-medium text-white transition-colors hover:bg-white/10"
+              >
+                {googleLoading ? (
+                  <LoaderCircleIcon className="size-4 animate-spin" />
+                ) : (
+                  <>
+                    <svg
+                      aria-hidden="true"
+                      className="mr-2 size-4"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        fill="#4285F4"
+                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                      />
+                      <path
+                        fill="#34A853"
+                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-1 .67-2.28 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                      />
+                      <path
+                        fill="#FBBC05"
+                        d="M5.84 14.09c-.22-.67-.35-1.39-.35-2.09s.13-1.42.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+                      />
+                      <path
+                        fill="#EA4335"
+                        d="M12 5.38c1.62 0 3.06.56 4.21 1.66l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                      />
+                    </svg>
+                    Google로 로그인
+                  </>
+                )}
+              </Button>
+            </>
+          )}
         </form>
 
         <p className="mt-4 text-center text-xs text-zinc-500">


### PR DESCRIPTION
Closes #15

## Summary
- Add a Google sign-in button to the Jarvis login modal.
- Reuse the existing `/api/auth/google` OAuth entry point and desktop deep-link return target.
- Persist returned Google auth sessions through the existing auth-session helper.

## Verification
- `corepack pnpm --dir "Jarvis Ui" --filter assistant-ui-starter-cloud exec tsc --noEmit`
- `git diff --check -- 'Jarvis Ui/templates/cloud/components/jarvis/login-modal.tsx'`

## Dev Validation
- Merged cleanly into `dev` via PR #16.

## Residual Risks
- Full Google OAuth success depends on backend Google client credentials being configured in the deployed auth service.